### PR TITLE
Fix dependencies for 1.3.3 release

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<311]
 
 requirements:
@@ -32,7 +32,7 @@ requirements:
     - pybind11 >=2.13.2,!=2.13.3
     - python
   run:
-    - numpy >=1.23
+    - numpy >=1.25
     - python
 
 test:


### PR DESCRIPTION
I didn't update the version of the `numpy` dependency in the recent 1.3.3 release. This does that, fixing #37.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.